### PR TITLE
feat: install & boot ubuntu from nvme

### DIFF
--- a/hosts-sample.yml
+++ b/hosts-sample.yml
@@ -12,12 +12,10 @@ all:
   vars:
     ansible_user: ubuntu
     hostname: turing
-    # If you are using the 4 nvme storage banks on the back,
-    # uncomment the storage section. this will format the block
-    # devices and add them to /etc/fstab
+    # If all 4 NVME storage banks are used,
+    # Ubuntu can be installed directly on the NVME storage and booted from there.
     #storage:
     #  block_device: /dev/nvme0n1
-    #  filesystem: ext4
     k3s:
       # create a random token with openssl
       # openssl rand -hex 64

--- a/roles/storage/tasks/main.yml
+++ b/roles/storage/tasks/main.yml
@@ -1,17 +1,11 @@
 ---
 - name: Preparing Storage
+  when: storage.block_device is defined and not ansible_facts.mounts | selectattr('mount', '==', '/') | selectattr('device', '==', "storage.block_device") | length == 0
   block:
-  - name: Creating a filesystem on block device
-    community.general.filesystem:
-      fstype: "{{ storage.filesystem }}"
-      dev: "{{ storage.block_device }}"
 
-  - name: Mount block device
-    ansible.posix.mount:
-      path: /var/lib/longhorn
-      src: "{{ storage.block_device }}"
-      fstype: "{{ storage.filesystem }}"
-      boot: true
-      opts: defaults
-      state: mounted
-  when: storage.block_device is defined and storage.filesystem is defined
+  - name: Installing root filesystem on block device {{ storage.block_device }}
+    ansible.builtin.shell: |
+      yes | /usr/bin/ubuntu-rockchip-install {{ storage.block_device }}
+
+  - name: Reboot the server to run from {{ storage.block_device }}
+    ansible.builtin.reboot:

--- a/turingpi.yml
+++ b/turingpi.yml
@@ -3,8 +3,8 @@
   gather_facts: yes
   become: yes
   roles:
-    - role: ubuntu
     - role: storage
+    - role: ubuntu
     - role: k3s-preparation
 
 - name: Install K3S Server


### PR DESCRIPTION
NVME handling changed. Ubuntu can be installed and started directly on the NVME storage.
https://docs.turingpi.com/docs/turing-rk1-flashing-os#running-off-an-external-block-device---method-2