### PR TITLE
fix: kured reboot stuck due to istio pdb

### DIFF
--- a/kubernetes-services/templates/istio.yaml
+++ b/kubernetes-services/templates/istio.yaml
@@ -24,6 +24,9 @@ spec:
       helm:
         values: |
           defaults:
+            pilot:
+              autoscaleEnabled: false
+              replicaCount: 2
             global:
               proxy:
                 tracer: "zipkin"


### PR DESCRIPTION
istiod pdb prevents the draining of nodes, so kured cannot reboot. 

Fix: autoscaling deactivated and replicaCount set to 2