### PR TITLE
fix: grafana pvc multiattach issue

### DIFF
--- a/kubernetes-services/templates/prometheus.yaml
+++ b/kubernetes-services/templates/prometheus.yaml
@@ -39,6 +39,8 @@ spec:
                       requests:
                         storage: 5Gi
           grafana:
+            deploymentStrategy:
+              type: Recreate
             grafana.ini:
               server:
                 root_url: /grafana/


### PR DESCRIPTION
Change grafana update strategy from rollingUpdates to recreate to avoid pvc multi attach errors

the old grafana deployment must be manually deleted
```
kubectl  --namespace monitoring delete deployments.apps prometheus-grafana
```